### PR TITLE
fix: add cmd/ttlx/main.go and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-ttlx
+/ttlx
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/ttlx/main.go
+++ b/cmd/ttlx/main.go
@@ -1,0 +1,14 @@
+// Package main is the entry point for the ttlx CLI tool.
+package main
+
+import (
+	"os"
+
+	"github.com/JHashimoto0518/ttlx/internal/cli"
+)
+
+func main() {
+	if err := cli.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Fixes #2

## Summary

This PR fixes the GitHub Actions build failure by:
- Creating `cmd/ttlx/main.go` with the user's local implementation
- Updating `.gitignore` to `/ttlx` to only ignore the binary in root, not the `cmd/ttlx/` directory

Generated with [Claude Code](https://claude.ai/code)