### PR TITLE
fix: Update octal literals to Go 1.21+ syntax

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -48,7 +48,7 @@ var buildCmd = &cobra.Command{
 			outputPath = strings.TrimSuffix(configPath, filepath.Ext(configPath)) + ".ttl"
 		}
 
-		if err := os.WriteFile(outputPath, []byte(ttl), 0644); err != nil {
+		if err := os.WriteFile(outputPath, []byte(ttl), 0o644); err != nil {
 			return fmt.Errorf("failed to write output: %w", err)
 		}
 

--- a/test/integration/build_test.go
+++ b/test/integration/build_test.go
@@ -115,7 +115,7 @@ func TestBuild_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	// 4. ファイル出力
-	err = os.WriteFile(outputPath, []byte(ttl), 0644)
+	err = os.WriteFile(outputPath, []byte(ttl), 0o644)
 	require.NoError(t, err)
 
 	// 5. ファイルが作成されたことを確認


### PR DESCRIPTION
Changed deprecated octal literals (0644) to modern syntax (0o644) to fix golangci-lint errors.

Files updated:
- internal/cli/build.go
- test/integration/build_test.go

Fixes #4

Generated with [Claude Code](https://claude.ai/code)