### PR TITLE
fix: include password in connect command to prevent authentication prompt

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -31,8 +31,8 @@ func Generate(cfg *config.Config, sourceFile string) (string, error) {
 			// 最初のステップ: connect コマンド
 			sb.WriteString(generateConnect(i+1, step.Profile, upperProfileName, profile))
 
-			// パスワード認証処理
-			if profile.Auth.Type == "password" {
+			// パスワード認証処理（connect コマンドに含まれていない場合のみ）
+			if profile.Auth.Type == "password" && profile.Auth.Value == "" {
 				sb.WriteString(generatePasswordAuth(step.Profile, profile.Auth))
 			}
 		} else {
@@ -79,8 +79,13 @@ func generateVariables(cfg *config.Config) string {
 func generateConnect(stepNum int, profileName, upperProfileName string, profile *config.Profile) string {
 	authType := profile.Auth.Type
 	keyfileOption := ""
+	passwordOption := ""
+
 	if authType == "keyfile" {
 		keyfileOption = fmt.Sprintf(" /keyfile=%s", profile.Auth.Path)
+	} else if authType == "password" && profile.Auth.Value != "" {
+		// パスワードが直接指定されている場合は connect コマンドに含める
+		passwordOption = fmt.Sprintf(" /passwd=%s", profile.Auth.Value)
 	}
 
 	return fmt.Sprintf(
@@ -93,6 +98,7 @@ func generateConnect(stepNum int, profileName, upperProfileName string, profile 
 		authType,
 		profile.User,
 		keyfileOption,
+		passwordOption,
 		upperProfileName,
 		upperProfileName,
 	)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -131,8 +131,10 @@ func TestGenerate_PasswordValue(t *testing.T) {
 	ttl, err := Generate(cfg, "test.yml")
 	require.NoError(t, err)
 
-	// 直接指定されたパスワードの確認
-	assert.Contains(t, ttl, "sendln 'secret123'")
+	// 直接指定されたパスワードの確認 - connect コマンドに含まれる
+	assert.Contains(t, ttl, "connect 'server.example.com:22 /ssh /auth=password /user=user /passwd=secret123'")
+	// 別途の sendln でパスワード送信がないことを確認
+	assert.NotContains(t, ttl, "sendln 'secret123'")
 }
 
 func TestGenerate_Components(t *testing.T) {

--- a/internal/generator/template.go
+++ b/internal/generator/template.go
@@ -19,7 +19,7 @@ timeout = %d
 	// 接続テンプレート（最初のステップ）
 	connectTemplate = `; === Step %d: %s ===
 :CONNECT_%s
-connect '%s:%d /ssh /auth=%s /user=%s%s'
+connect '%s:%d /ssh /auth=%s /user=%s%s%s'
 if result <> 0 then
     goto :ERROR_CONNECT_%s
 endif


### PR DESCRIPTION
## Summary

Fixed SSH2 auto-login authentication error by including the password directly in the `connect` command using the `/passwd` parameter.

## Changes

- Modified TTL generator to include `/passwd` parameter in connect command when password is specified via `auth.value`
- Skip separate password sendln when password is included in connect command
- Updated tests to match new behavior

Fixes #6

———
🤖 Generated with [Claude Code](https://claude.ai/code)