### PR TITLE
fix: handle errors from flag getters in build command

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -18,8 +18,14 @@ var buildCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		configPath := args[0]
-		outputPath, _ := cmd.Flags().GetString("output")
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		outputPath, err := cmd.Flags().GetString("output")
+		if err != nil {
+			return fmt.Errorf("failed to get output flag: %w", err)
+		}
+		dryRun, err := cmd.Flags().GetBool("dry-run")
+		if err != nil {
+			return fmt.Errorf("failed to get dry-run flag: %w", err)
+		}
 
 		// 1. 設定読み込み
 		cfg, err := config.LoadConfig(configPath)


### PR DESCRIPTION
## Summary

This PR fixes GitHub Actions lint failures caused by golangci-lint errcheck violations.

## Changes

- Fixed error handling in `internal/cli/build.go` by properly checking errors from `cmd.Flags().GetString()` and `cmd.Flags().GetBool()`

## Related Issue

Closes #11

---
Generated with [Claude Code](https://claude.ai/code)