### PR TITLE
docs: update GitHub Actions versions in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,8 +219,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: Lint
@@ -245,8 +245,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
       - uses: goreleaser/goreleaser-action@v5
         with:
           version: latest


### PR DESCRIPTION
## Summary

Update example workflow snippets in `docs/architecture.md` to reflect the latest GitHub Actions versions.

### Changes

| Item | Before | After |
|------|--------|-------|
| actions/checkout | v4 | v6 |
| actions/setup-go | v5 | v6 |

## Test plan

- [x] Documentation update only, no code changes

Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)